### PR TITLE
Abstracted ViewModel of CocoaAction

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "neilpa/Rex" "0.9.0-RC.2"
+github "neilpa/Rex" "0.9.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "antitypical/Result" "1.0.1"
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-RC.2"
-github "neilpa/Rex" "0.9.0-RC.2"
+github "antitypical/Result" "1.0.2"
+github "ReactiveCocoa/ReactiveCocoa" "v4.0.1"
+github "neilpa/Rex" "0.9.0"

--- a/RACNest/Components/RAC Extensions/RacExtensions.swift
+++ b/RACNest/Components/RAC Extensions/RacExtensions.swift
@@ -9,6 +9,7 @@
 import UIKit
 import ReactiveCocoa
 import Rex
+import Result
 
 extension UITextField {
 

--- a/RACNest/ViewControllers/Form/Components/FormViewModel.swift
+++ b/RACNest/ViewControllers/Form/Components/FormViewModel.swift
@@ -11,19 +11,28 @@ import ReactiveCocoa
 import Result
 
 struct FormViewModel {
-    
+
+    let authenticateAction: Action<Void, Void, NoError>
+
     let username: MutableProperty<String>
     let password: MutableProperty<String>
-
-    private let isFormValid: MutableProperty<Bool>
-
-    private(set) lazy var authenticateAction: Action<Void, Void, NoError> = {
+    
+    init(credentialsValidationRule: (String, String) -> Bool = validateCredentials) {
         
-        return Action<Void, Void, NoError>(enabledIf: self.isFormValid, { _ in
+        let username = NSUserDefaults.value(forKey: .Username)
+        let password = NSUserDefaults.value(forKey: .Password)
+        
+        let usernameProperty = MutableProperty(username)
+        let passwordProperty = MutableProperty(password)
+
+        let isFormValid = MutableProperty(credentialsValidationRule(username, password))
+        isFormValid <~ combineLatest(usernameProperty.producer, passwordProperty.producer).map(credentialsValidationRule)
+
+        let authenticateAction = Action<Void, Void, NoError>(enabledIf: isFormValid, { _ in
             return SignalProducer { o, d in
 
-                let username = self.username.value ?? ""
-                let password = self.password.value ?? ""
+                let username = usernameProperty.value ?? ""
+                let password = passwordProperty.value ?? ""
 
                 NSUserDefaults.setValue(username, forKey: .Username)
                 NSUserDefaults.setValue(password, forKey: .Password)
@@ -31,18 +40,10 @@ struct FormViewModel {
                 o.sendCompleted()
             }
         })
-    }()
-    
-    init(credentialsValidationRule: (String, String) -> Bool = validateCredentials) {
-        
-        let username = NSUserDefaults.value(forKey: .Username)
-        let password = NSUserDefaults.value(forKey: .Password)
-        
-        self.username = MutableProperty(username)
-        self.password = MutableProperty(password)
-        
-        isFormValid = MutableProperty(credentialsValidationRule(username, password))
-        isFormValid <~ combineLatest(self.username.producer, self.password.producer).map(credentialsValidationRule)
+
+        self.username = usernameProperty
+        self.password = passwordProperty
+        self.authenticateAction = authenticateAction
     }
 
 }

--- a/RACNest/ViewControllers/Form/Components/FormViewModel.swift
+++ b/RACNest/ViewControllers/Form/Components/FormViewModel.swift
@@ -48,6 +48,14 @@ struct FormViewModel {
 
 }
 
+extension FormViewModel {
+
+    var authenticate: CocoaAction {
+        return CocoaAction(authenticateAction, input: ())
+    }
+
+}
+
 private func validateCredentials(username: String, password: String) -> Bool {
     
     let usernameRule = username.characters.count > 5

--- a/RACNest/ViewControllers/Form/Components/FormViewModel.swift
+++ b/RACNest/ViewControllers/Form/Components/FormViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import Result
 
 struct FormViewModel {
     

--- a/RACNest/ViewControllers/Form/FormViewController.swift
+++ b/RACNest/ViewControllers/Form/FormViewController.swift
@@ -25,8 +25,8 @@ final class FormViewController: UIViewController {
         
         viewModel.username <~ usernameField.rex_textSignal
         viewModel.password <~ passwordField.rex_textSignal
-        
-        loginButton.rex_pressed <~ SignalProducer(value: viewModel.authenticate)
+
+        loginButton.rex_pressed <~ SignalProducer(value: CocoaAction(viewModel.authenticateAction) { _ in })
         
         usernameField.becomeFirstResponder()
     }

--- a/RACNest/ViewControllers/Form/FormViewController.swift
+++ b/RACNest/ViewControllers/Form/FormViewController.swift
@@ -26,7 +26,7 @@ final class FormViewController: UIViewController {
         viewModel.username <~ usernameField.rex_textSignal
         viewModel.password <~ passwordField.rex_textSignal
 
-        loginButton.rex_pressed <~ SignalProducer(value: CocoaAction(viewModel.authenticateAction) { _ in })
+        loginButton.rex_pressed <~ SignalProducer(value: viewModel.authenticate)
         
         usernameField.becomeFirstResponder()
     }

--- a/RACNest/ViewControllers/Search/Components/SearchViewModel.swift
+++ b/RACNest/ViewControllers/Search/Components/SearchViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ReactiveCocoa
 import Rex
+import Result
 
 struct SearchViewModel {
     


### PR DESCRIPTION
### Motivation

Since `CocoaAction` is directly related with the user interface, in theory seems more logical keeping the ViewModel only responsible for provide an action that can be used by the interface which in turn can opt in for doing the wrapping.

By exposing the `Action` itself we also have more flexibility to handle errors resulting of the execution of the action.
